### PR TITLE
Replace sha1 and md5 checksums with sha256

### DIFF
--- a/Formula/cryopng.rb
+++ b/Formula/cryopng.rb
@@ -3,8 +3,7 @@ require 'formula'
 class Cryopng <Formula
   url 'http://frdx.free.fr/cryopng/cryopng-macosx-ub.tgz'
   homepage 'http://frdx.free.fr/cryopng/'
-  md5 'b01942b43f7c098aaf585e3b1b72a852'
-  sha1 'dfd72c1ad81e02441591d438ea0782b54fa12fae'
+  sha256 'fd2981ba1c0e08018623dbc355554716ac814a1519ca5b91679260f0ef967a34'
   @version='0.6.4'
 
   def install

--- a/Formula/defluff.rb
+++ b/Formula/defluff.rb
@@ -3,8 +3,7 @@ require 'formula'
 class Defluff <Formula
   url 'https://raw.github.com/imgo/imgo-tools/master/src/defluff/defluff-0.3.2-darwin-x86.zip'
   homepage 'http://encode.ru/threads/1214-defluff-a-deflate-huffman-optimizer'
-  md5 '37811640ba84c6180dc477596a89302a'
-  sha1 'b0f7bba518ad55bc713334f05cdd284d43652bb2'
+  sha256 'e94044a2a478cfa6a9fc8a27d39a68c8b9b5c46ab1257837a2326089a3872f71'
   @version='0.3.2'
 
   def install

--- a/Formula/imgo.rb
+++ b/Formula/imgo.rb
@@ -3,7 +3,6 @@ require 'formula'
 class Imgo <Formula
   url 'git://github.com/imgo/imgo.git'
   homepage 'http://imgcomp.com'
-  md5 'bb0b7af34236ae5b475b8902602df11b'
   version '0.8'
 
  depends_on 'imagemagick'

--- a/Formula/pngout.rb
+++ b/Formula/pngout.rb
@@ -3,8 +3,7 @@ require 'formula'
 class Pngout <Formula
   url 'http://static.jonof.id.au/dl/kenutils/pngout-20110722-darwin.tar.gz'
   homepage 'http://www.jonof.id.au/kenutils'
-  md5 'ce70a9d70e08b1920e5ac88d130d0eb9'
-  sha1 'f268caf5d5c72fc9a0dd42db38839b4a6b9c7094'
+  sha256 '45f27bb4a76f1ed1d93734d5fe2a601ef9d21eafbe7ad230fa60c00315b09167'
   @version='2011.07.22'
 
   def install

--- a/Formula/pngrewrite.rb
+++ b/Formula/pngrewrite.rb
@@ -4,7 +4,7 @@ class Pngrewrite <Formula
   homepage "http://entropymine.com/jason/pngrewrite/"
   url "http://entropymine.com/jason/pngrewrite/pngrewrite-1.4.0.zip"
   version "1.4.0"
-  sha1 "c959fbd507d84c6d4544d09493934b268e969b56"
+  sha256 "24c3706bcd55b3f957b2590f1cf19ca4dd3f5bc8310db47e464140ce773a94c3"
 
   def install
   	system "make"


### PR DESCRIPTION
When I tried to install imgo on macOS Sierra 10.12.6 and Homebrew 1.6.3, I got a bunch of errors like this:
 
```
Error: undefined method `sha1' for #<Class:0x000001011fe558>
Please report this bug:
  https://docs.brew.sh/Troubleshooting
/Users/user/Library/Caches/Homebrew/Formula/pngrewrite.rb:7:in `<class:Pngrewrite>'
/Users/user/Library/Caches/Homebrew/Formula/pngrewrite.rb:3:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:26:in `module_eval'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:26:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:46:in `load_formula_from_path'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:101:in `load_file'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:174:in `load_file'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:92:in `klass'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:88:in `get_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:280:in `factory'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:46:in `block in formulae'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:44:in `map'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:44:in `formulae'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:117:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:101:in `<main>'

Error: undefined method `md5' for #<Class:0x00000101b09e68>
Please report this bug:
  https://docs.brew.sh/Troubleshooting
/Users/user/Library/Caches/Homebrew/Formula/pngout.rb:6:in `<class:Pngout>'
/Users/user/Library/Caches/Homebrew/Formula/pngout.rb:3:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:26:in `module_eval'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:26:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:46:in `load_formula_from_path'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:101:in `load_file'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:174:in `load_file'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:92:in `klass'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:88:in `get_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:280:in `factory'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:46:in `block in formulae'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:44:in `map'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:44:in `formulae'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:117:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:101:in `<main>'
```

it occurs because [sha1 & md5 checksums for brew formulae is deprecated](https://docs.brew.sh/Checksum_Deprecation). I replace sha1 & md5 checksums with sha256.

You can try it out:

```
formulas='pngrewrite.rb pngout.rb  defluff.rb cryopng.rb imgo.rb'
for package in $formulas
do
  brew install "https://raw.github.com/isqua/imgo-tools/sha256/Formula/"$package
done
```